### PR TITLE
PP-8641 Remove broken deploy credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ script:
 after_success:
   # Check to see if the version file has been updated
   - ./create-release-tag.sh
-deploy:
-  provider: heroku
-  api_key:
-    secure: h/9/Rcd41XVU4VYYeBoKKvG6uShEoDksCGGZ/2dgeY1f3tYnhGzzgL6TIkvhafwDbKk2Y4o6d/MI05K+s7lorf2uTKpr1To2o52hQqmb4YREPWruZtBqoRo5X4nCeN2oEdW+yJRH3jZDNUmwkPzjytqxkcUUUeDPHfz3+xCtSZk=
-  app: govuk-prototype-kit
-  on: master
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> As of September 2021 this repository is no longer actively maintained by the GOV.UK Pay team.
+
 # GOV.UK Prototype kit
 
 ## News


### PR DESCRIPTION
This repo was still using the old travis-ci.org integration, which was sunsetted June 2021. The deployment credentials do not work at present.

This repository is also no longer needed (the Heroku prototype itself is no longer accessible) so have added an archive notice to the README. I'll archive once this PR is merged.